### PR TITLE
update(rhs, hcof, AdvancedInput): bug fixes for advanced variables

### DIFF
--- a/modflowapi/extensions/data.py
+++ b/modflowapi/extensions/data.py
@@ -605,11 +605,9 @@ class AdvancedInput(object):
             # this is a set value situation
             self.mf6.set_value(
                 self.mf6.get_var_address(
-                    name.upper(),
-                    self.parent.model.name,
-                    self.parent.pkg_name
+                    name.upper(), self.parent.model.name, self.parent.pkg_name
                 ),
-                values
+                values,
             )
         else:
             self._ptrs[name.lower()] = values

--- a/modflowapi/extensions/data.py
+++ b/modflowapi/extensions/data.py
@@ -610,7 +610,7 @@ class AdvancedInput(object):
                 values,
             )
         else:
-            self._ptrs[name.lower()] = values
+            self._ptrs[name.lower()][:] = values[:]
 
 
 class ScalarInput:

--- a/modflowapi/extensions/data.py
+++ b/modflowapi/extensions/data.py
@@ -558,10 +558,10 @@ class AdvancedInput(object):
 
         try:
             values = self.mf6.get_value_ptr(var_addr)
+            self._ptrs[name.lower()] = values
         except xmipy.errors.InputError:
             values = self.mf6.get_value(var_addr)
 
-        self._ptrs[name.lower()] = values
         return values.copy()
 
     def set_variable(self, name, values, model=None, package=None):
@@ -601,7 +601,18 @@ class AdvancedInput(object):
                 f"current shape={values.shape}, valid shape={values0.shape}"
             )
 
-        self._ptrs[name.lower()] = values
+        if name.lower() not in self._ptrs:
+            # this is a set value situation
+            self.mf6.set_value(
+                self.mf6.get_var_address(
+                    name.upper(),
+                    self.parent.model.name,
+                    self.parent.pkg_name
+                ),
+                values
+            )
+        else:
+            self._ptrs[name.lower()] = values
 
 
 class ScalarInput:

--- a/modflowapi/extensions/pakbase.py
+++ b/modflowapi/extensions/pakbase.py
@@ -341,7 +341,7 @@ class PackageBase:
         if self._rhs is None:
             return
 
-        self._rhs = values
+        self._rhs[:] = values[:]
 
     @property
     def hcof(self):
@@ -362,7 +362,7 @@ class PackageBase:
         if self._hcof is None:
             return
 
-        self.__hcof = values
+        self._hcof[:] = values[:]
 
 
 class ListPackage(PackageBase):


### PR DESCRIPTION
* update rhs and hcof to copy values to pointer instead of overwriting the pointer
* add a check for AdvancedInput variables that do not have pointer support in xmipy