### PR TITLE
ci(release): add release workflow and versioning script

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,273 @@
+name: Release
+on:
+  push:
+    branches:
+      - main
+      - v[0-9]+.[0-9]+.[0-9]+*
+  release:
+    types:
+      - published
+jobs:
+  prep:
+    name: Prepare release
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'push' && github.ref_name != 'main' }}
+    permissions:
+      contents: write
+      pull-requests: write
+    defaults:
+      run:
+        shell: bash
+    steps:
+
+      - name: Checkout release branch
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.8
+          cache: 'pip'
+          cache-dependency-path: pyproject.toml
+
+      - name: Install Python dependencies
+        run: |
+          pip install --upgrade pip
+          pip install build twine
+          pip install .
+          pip install ".[lint, test]"
+
+      - name: Update version
+        id: version
+        run: |
+          ref="${{ github.ref_name }}"
+          version="${ref#"v"}"
+          python scripts/update_version.py -v "$version"
+          python -c "import modflowapi; print('Version: ', modflowapi.__version__)"
+          echo "version=$version" >> $GITHUB_OUTPUT
+
+      - name: Touch changelog
+        run: touch HISTORY.md
+
+      - name: Generate changelog
+        id: cliff
+        uses: orhun/git-cliff-action@v1
+        with:
+          config: cliff.toml
+          args: --verbose --unreleased --tag ${{ steps.version.outputs.version }}
+        env:
+          OUTPUT: CHANGELOG.md
+
+      - name: Update changelog
+        id: update-changelog
+        run: |
+          # move changelog
+          clog="CHANGELOG_${{ steps.version.outputs.version }}.md"
+          echo "changelog=$clog" >> $GITHUB_OUTPUT
+          sudo cp "${{ steps.cliff.outputs.changelog }}" "$clog"
+          
+          # show current release changelog
+          cat "$clog"
+          
+          # substitute full group names
+          sed -i 's/#### Ci/#### Continuous integration/' "$clog"
+          sed -i 's/#### Feat/#### New features/' "$clog"
+          sed -i 's/#### Fix/#### Bug fixes/' "$clog"
+          sed -i 's/#### Refactor/#### Refactoring/' "$clog"
+          sed -i 's/#### Test/#### Testing/' "$clog"
+          
+          cat "$clog" HISTORY.md > temp_history.md
+          sudo mv temp_history.md HISTORY.md
+          
+          # show full changelog
+          cat HISTORY.md
+
+      - name: Upload changelog
+        uses: actions/upload-artifact@v3
+        with:
+          name: changelog
+          path: ${{ steps.update-changelog.outputs.changelog }}
+      
+      - name: Format Python files
+        run: python scripts/pull_request_prepare.py
+
+      - name: Push release branch
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          ver="${{ steps.version.outputs.version }}"
+          changelog=$(cat ${{ steps.update-changelog.outputs.changelog }} | grep -v "### Version $ver")
+          
+          # remove this release's changelog so we don't commit it
+          # the changes have already been prepended to HISTORY.md
+          rm ${{ steps.update-changelog.outputs.changelog }}
+          rm -f CHANGELOG.md
+          
+          # commit and push changes
+          git config core.sharedRepository true
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add -A
+          git commit -m "ci(release): set version to ${{ steps.version.outputs.version }}, update changelog"
+          git push origin "${{ github.ref_name }}"
+
+          title="Release $ver"
+          body='
+          # Release '$ver'
+          
+          The release can be approved by merging this pull request into `main`. This will trigger jobs to publish the release to PyPI and reset `develop` from `main`, incrementing the minor version number.
+          
+          ## Changelog
+          
+          '$changelog'
+          '
+          gh pr create -B "main" -H "${{ github.ref_name }}" --title "$title" --draft --body "$body"
+
+  release:
+    name: Draft release
+    # runs only when changes are merged to main
+    if: ${{ github.event_name == 'push' && github.ref_name == 'main' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+
+      - name: Checkout repo
+        uses: actions/checkout@v3
+        with:
+          ref: main
+        
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.8
+
+      - name: Install Python dependencies
+        run: |
+          pip install --upgrade pip
+          pip install .
+          pip install ".[test]"
+
+      # actions/download-artifact won't look at previous workflow runs but we need to in order to get changelog
+      - name: Download artifacts
+        uses: dawidd6/action-download-artifact@v2
+
+      - name: Draft release
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          version=$(python scripts/update_version.py -g)
+          title="modflowapi $version"
+          notes=$(cat "changelog/CHANGELOG_$version.md" | grep -v "### Version $version")
+          gh release create "$version" \
+            --target main \
+            --title "$title" \
+            --notes "$notes" \
+            --draft \
+            --latest
+
+  publish:
+    name: Publish package
+    # runs only after release is published (manually promoted from draft)
+    if: github.event_name == 'release' && github.repository_owner == 'MODFLOW-USGS'
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+
+      - name: Checkout main branch
+        uses: actions/checkout@v3
+        with:
+          ref: main
+
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.8
+
+      - name: Install Python dependencies
+        run: |
+          pip install --upgrade pip
+          pip install build twine
+          pip install .
+
+      - name: Build package
+        run: python -m build
+      
+      - name: Check package
+        run: twine check --strict dist/*
+
+      - name: Publish package
+        run: twine upload dist/*
+
+  reset:
+    name: Draft reset PR
+    if: ${{ github.event_name == 'release' }}
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+
+      - name: Checkout main branch
+        uses: actions/checkout@v3
+        with:
+          ref: main
+
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.8
+          cache: 'pip'
+          cache-dependency-path: pyproject.toml
+
+      - name: Install Python dependencies
+        run: |
+          pip install --upgrade pip
+          pip install .
+          pip install ".[lint, test]"
+
+      - name: Get release tag
+        uses: oprypin/find-latest-tag@v1
+        id: latest_tag
+        with:
+          repository: ${{ github.repository }}
+          releases-only: true
+
+      - name: Draft pull request
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          # create reset branch from main
+          reset_branch="post-release-${{ steps.latest_tag.outputs.tag }}-reset"
+          git switch -c $reset_branch
+
+          # increment minor version
+          major_version=$(echo "${{ steps.latest_tag.outputs.tag }}" | cut -d. -f1)
+          minor_version=$(echo "${{ steps.latest_tag.outputs.tag }}" | cut -d. -f2)
+          patch_version=0
+          version="$major_version.$((minor_version + 1)).$patch_version"
+          python scripts/update_version.py -v "$version"
+
+          # format Python files
+          python scripts/pull_request_prepare.py
+
+          # commit and push reset branch
+          git config core.sharedRepository true
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add -A
+          git commit -m "ci(release): update to development version $version"
+          git push -u origin $reset_branch
+
+          # create PR into develop
+          body='
+          # Reinitialize for development
+
+          Updates the `develop` branch from `main` following a successful release. Increments the minor version number.
+          '
+          gh pr create -B "develop" -H "$reset_branch" --title "Reinitialize develop branch" --draft --body "$body"

--- a/cliff.toml
+++ b/cliff.toml
@@ -1,0 +1,46 @@
+# configuration file for git-cliff (0.1.0)
+
+[changelog]
+body = """
+{% if version %}\
+    ### Version {{ version | trim_start_matches(pat="v") }}
+{% else %}\
+    ### [unreleased]
+{% endif %}\
+{% for group, commits in commits | group_by(attribute="group") %}
+    #### {{ group | upper_first }}
+    {% for commit in commits %}
+        * [{{ commit.group }}{% if commit.scope %}({{ commit.scope }}){% endif %}](https://github.com/MODFLOW-USGS/modflowapi/commit/{{ commit.id }}): {% if commit.breaking %}[**breaking**] {% endif %}{{ commit.message | upper_first }}. Committed by {{ commit.author.name }} on {{ commit.author.timestamp | date(format="%Y-%m-%d") }}.\
+    {% endfor %}
+{% endfor %}\n
+"""
+trim = true
+
+[git]
+conventional_commits = true
+filter_unconventional = true
+split_commits = false
+commit_parsers = [
+    { message = "^[fF]eat", group = "feat"},
+    { message = "^[fF]ix", group = "fix"},
+    { message = "^[bB]ug", group = "fix"},
+    { message = "^[pP]erf", group = "perf"},
+    { message = "^[rR]efactor", group = "refactor"},
+    { message = "^[uU]pdate", group = "refactor"},
+    { message = "^[aA]dd", group = "refactor"},
+    { message = "^[dD]oc.*", group = "docs", skip = true},
+    { message = "^[bB]inder", group = "docs", skip = true},
+    { message = "^[nN]otebook.*", group = "docs", skip = true},
+    { message = "^[rR][eE][aA][dD].*", group = "docs", skip = true},
+    { message = "^[sS]tyl.*", group = "style", skip = true},
+    { message = "^[tT]est.*", group = "test", skip = true},
+    { message = "^[cC][iI]", skip = true},
+    { message = "^[cC][iI]\\(release\\):", skip = true},
+    { message = "^[rR]elease", skip = true},
+    { message = "^[cC]hore", group = "chore", skip = true},
+]
+protect_breaking_commits = false
+filter_commits = false
+tag_pattern = "[0-9].[0-9].[0-9]"
+ignore_tags = ""
+sort_commits = "oldest"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ test = [
 lint = [
     "black",
     "flake8",
+    "isort",
     "pylint",
 ]
 

--- a/scripts/pull_request_prepare.py
+++ b/scripts/pull_request_prepare.py
@@ -1,0 +1,22 @@
+import os
+
+try:
+    import isort
+
+    print(f"isort version: {isort.__version__}")
+except ModuleNotFoundError:
+    print("isort not installed\n\tInstall using pip install isort")
+
+try:
+    import black
+
+    print(f"black version: {black.__version__}")
+except ModuleNotFoundError:
+    print("black not installed\n\tInstall using pip install black")
+
+# uncomment if/when isort used
+# print("running isort...")
+# os.system("isort -v ../modflowapi")
+
+print("running black...")
+os.system("black -v ../modflowapi")

--- a/scripts/update_version.py
+++ b/scripts/update_version.py
@@ -1,0 +1,152 @@
+import argparse
+import textwrap
+from datetime import datetime
+from enum import Enum
+from os import PathLike
+from pathlib import Path
+from typing import NamedTuple
+
+from filelock import FileLock
+
+_project_name = "modflowapi"
+_project_root_path = Path(__file__).parent.parent
+_version_py_path = _project_root_path / "modflowapi" / "version.py"
+_citation_cff_path = _project_root_path / "CITATION.cff"
+
+
+class Version(NamedTuple):
+    """Semantic version number"""
+
+    major: int = 0
+    minor: int = 0
+    patch: int = 0
+
+    def __repr__(self):
+        return f"{self.major}.{self.minor}.{self.patch}"
+
+    @classmethod
+    def from_string(cls, version: str) -> "Version":
+        t = version.split(".")
+
+        vmajor = int(t[0])
+        vminor = int(t[1])
+        vpatch = int(t[2])
+
+        return cls(major=vmajor, minor=vminor, patch=vpatch)
+
+    @classmethod
+    def from_file(cls, path: PathLike) -> "Version":
+        lines = [
+            line.rstrip("\n")
+            for line in open(Path(path).expanduser().absolute(), "r")
+        ]
+        vmajor = vminor = vpatch = None
+        for line in lines:
+            line = line.strip()
+            if not any(line):
+                continue
+
+            def get_ver(l):
+                return l.split("=")[1]
+
+            if "__version__" not in line:
+                if "major" in line:
+                    vmajor = int(get_ver(line))
+                elif "minor" in line:
+                    vminor = int(get_ver(line))
+                elif "patch" in line or "micro" in line:
+                    vpatch = int(get_ver(line))
+
+        assert (
+            vmajor is not None and vminor is not None and vpatch is not None
+        ), "version string must follow semantic version format: major.minor.patch"
+        return cls(major=vmajor, minor=vminor, patch=vpatch)
+
+
+_initial_version = Version(0, 0, 1)
+_current_version = Version.from_file(_version_py_path)
+
+
+def update_version_py(timestamp: datetime, version: Version):
+    with open(_version_py_path, "w") as f:
+        f.write(
+            f"# {_project_name} version file automatically created using "
+            f"{Path(__file__).name} on {timestamp:%B %d, %Y %H:%M:%S}\n\n"
+        )
+        f.write(f"major = {version.major}\n")
+        f.write(f"minor = {version.minor}\n")
+        f.write(f"micro = {version.patch}\n")
+        f.write("__version__ = f'{major}.{minor}.{micro}'\n")
+    print(f"Updated {_version_py_path} to version {version}")
+
+def update_citation_cff(timestamp: datetime, version: Version):
+    lines = open(_citation_cff_path, "r").readlines()
+    with open(_citation_cff_path, "w") as f:
+        for line in lines:
+            if line.startswith("version:"):
+                line = f"version: {version}\n"
+            f.write(line)
+    print(f"Updated {_citation_cff_path} to version {version}")
+
+def update_version(
+    timestamp: datetime = datetime.now(),
+    version: Version = None,
+):
+    lock_path = Path(_version_py_path.name + ".lock")
+    try:
+        lock = FileLock(lock_path)
+        previous = Version.from_file(_version_py_path)
+        version = (
+            version
+            if version
+            else Version(previous.major, previous.minor, previous.patch)
+        )
+
+        with lock:
+            update_version_py(timestamp, version)
+            update_citation_cff(timestamp, version)
+    finally:
+        try:
+            lock_path.unlink()
+        except:
+            pass
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        prog=f"Update {_project_name} version",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=textwrap.dedent(
+            """\
+            Update version information stored in version.txt in the project root,
+            as well as several other files in the repository. If --version is not
+            provided, the version number will not be changed. A file lock is held
+            to synchronize file access. The version tag must comply with standard
+            '<major>.<minor>.<patch>' format conventions for semantic versioning.
+            """
+        ),
+    )
+    parser.add_argument(
+        "-v",
+        "--version",
+        required=False,
+        help="Specify the release version",
+    )
+    parser.add_argument(
+        "-g",
+        "--get",
+        required=False,
+        action="store_true",
+        help="Just get the current version number, don't update anything (defaults to false)",
+    )
+    args = parser.parse_args()
+
+    if args.get:
+        print(_current_version)
+    else:
+        update_version(
+            timestamp=datetime.now(),
+            version=Version.from_string(args.version)
+            if args.version
+            else _current_version,
+        )


### PR DESCRIPTION
- Add `.github/workflows/release.yml` to automate releases. The workflow is triggered when a branch matching semantic version format and prefixed with `v` (e.g. `v0.2.1`) is pushed. The steps happen automatically for the most part (_italics_), with maintainer action (**bold**) only needed to trigger the process and then review/greenlight each stage 

  1. **Push release branch**
  2. _Lint, update version strings, build, test, update changelog, and open PR against `main`_
  3. **Merge to `main`** (not squash/rebase, to preserve history)
  4. _Draft GitHub release post_
  5. **Publish GitHub release**
  6. _Publish package to PyPI_
  7. _Open PR against `develop` branch from `main` to reset for next development phase_
  8. **Merge to `develop`** (not squash/rebase)

- Use [`git-cliff`](https://github.com/orhun/git-cliff) to autogenerate changelog. On the next release this will add a `HISTORY.md` cumulative changelog file.

- Add `scripts/pull_request_prepare.py` which runs `black` on the modflowapi main module. Could also `isort` but this caused even more merge conflicts, and was not previously done, so disabled for now. Add `isort` to the `lint` dependency group in `pyproject.toml` though.

- Add `scripts/update_version.py` to update version strings embedded in the `modflowapi` module and `CITATION.cff`. This is used in the automatic release workflow above and should generally not need to run locally. Example usage:

  ```shell
  $ python scripts/update_version.py -v 0.1.1
  Updated /***/modflowapi/modflowapi/version.py to version 0.1.1
  Updated /***/modflowapi/CITATION.cff to version 0.1.1
  ```

  It can also be used to get the current version with `--get` (short `-g`)

  ```shell
  $ python scripts/update_version.py -g
  0.1.1
  ```

### Notes

#### Merge conflicts & preserving history

On the first automated release, there will likely be merge conflicts to resolve in the PR created on `main`. This is because when releases are squashed into `main`, it diverges from `develop`.

In the future, releases can merge (not squash) to `main` to avoid this, then merge (again not squash) the development reset PR back into `develop`. (The cumulative changelog may also need manual correction the first time for the same reason.)

#### Major, minor & patch releases

The workflow here should work for releases of all three levels, with major and minor releases generally expected to branch from `develop`, where the main development efforts occur, and patch (micro) releases branching from `main` for narrow-scoped bug-fixes.

#### PyPI authentication

The `release.yml` workflow does not use twine username/password to authenticate with PyPI during the publish step. Instead it is assumed that `modflowapi` has been [configured in PyPI to use trusted publishing](https://docs.pypi.org/trusted-publishers/adding-a-publisher/). Repository secrets for twine username/password are not needed.

#### Testing

Full procedure test run (except publishing to PyPI):

- [release PR](https://github.com/w-bonelli/modflowapi/pull/14) (changelog incorrect due to branch history divergence)
- [release](https://github.com/w-bonelli/modflowapi/releases/tag/0.1.1) (")
- [reset PR](https://github.com/w-bonelli/modflowapi/pull/15)