### PR TITLE
refactor: support python3.12, pin numpy<2, add status classifier

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,7 +101,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
-        python-version: [ 3.8, 3.9, "3.10", "3.11" ]
+        python-version: [ 3.8, 3.9, "3.10", "3.11", "3.12" ]
     defaults:
       run:
         shell: bash
@@ -144,7 +144,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
-        python-version: [ 3.8, 3.9, "3.10", "3.11" ]
+        python-version: [ 3.8, 3.9, "3.10", "3.11", "3.12" ]
     defaults:
       run:
         shell: bash
@@ -188,7 +188,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
-        python-version: [ 3.8, 3.9, "3.10", "3.11" ]
+        python-version: [ 3.8, 3.9, "3.10", "3.11", "3.12" ]
     defaults:
       run:
         shell: bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ readme = "README.md"
 keywords = ["MODFLOW", "groundwater", "hydrogeology", "bmi", "xmi"]
 license = {text = "CC0"}
 classifiers = [
+    "Development Status :: 4 - Beta",
     "Intended Audience :: Science/Research",
     "License :: CC0 1.0 Universal (CC0 1.0) Public Domain Dedication",
     "Programming Language :: Python :: 3",
@@ -28,11 +29,12 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: Scientific/Engineering :: Hydrology",
 ]
 requires-python = ">=3.8"
 dependencies = [
-    "numpy",
+    "numpy<2.0.0",
     "pandas",
     "xmipy",  # develop branch from github.com/Deltares/xmipy
 ]


### PR DESCRIPTION
* add project status classifier to `pyproject.toml`
* add python3.12 classifier to `pyproject.toml`
* add python3.12 to CI test matrices
* pin numpy<2.0.0