### PR TITLE
chore(dependencies): drop py3.8 support, restrict yanked pytest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,7 +101,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
-        python-version: [ 3.8, 3.9, "3.10", "3.11", "3.12" ]
+        python-version: [ 3.9, "3.10", "3.11", "3.12" ]
     defaults:
       run:
         shell: bash
@@ -144,7 +144,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
-        python-version: [ 3.8, 3.9, "3.10", "3.11", "3.12" ]
+        python-version: [ 3.9, "3.10", "3.11", "3.12" ]
     defaults:
       run:
         shell: bash
@@ -188,7 +188,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
-        python-version: [ 3.8, 3.9, "3.10", "3.11", "3.12" ]
+        python-version: [ 3.9, "3.10", "3.11", "3.12" ]
     defaults:
       run:
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: 3.9
           cache: 'pip'
           cache-dependency-path: pyproject.toml
 
@@ -135,7 +135,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: 3.9
 
       - name: Install Python dependencies
         run: |
@@ -183,7 +183,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: 3.9
 
       - name: Install Python dependencies
         run: |

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ and additional functionality specific to the MODFLOW API. Currently it is a join
 
 ## Installation
 
-`modflowapi` requires Python 3.8+, with:
+`modflowapi` requires Python 3.9+, with:
 
 ```shell
 numpy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,25 +25,24 @@ classifiers = [
     "License :: CC0 1.0 Universal (CC0 1.0) Public Domain Dedication",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Topic :: Scientific/Engineering :: Hydrology",
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dependencies = [
     "numpy<2.0.0",
     "pandas",
-    "xmipy",  # develop branch from github.com/Deltares/xmipy
+    "xmipy",
 ]
 
 [project.optional-dependencies]
 dev = ["modflowapi[test,lint]"]
 test = [
     "filelock",
-    "modflow-devtools",  # develop branch from github.com/MODFLOW-USGS/modflow-devtools
+    "modflow-devtools",
     "pytest!=8.1.0",
     "pytest-order",
     "pytest-xdist",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ dev = ["modflowapi[test,lint]"]
 test = [
     "filelock",
     "modflow-devtools",  # develop branch from github.com/MODFLOW-USGS/modflow-devtools
-    "pytest",
+    "pytest!=8.1.0",
     "pytest-order",
     "pytest-xdist",
 ]


### PR DESCRIPTION
* https://github.com/pytest-dev/pytest/releases/tag/8.1.0 broke some plugins and was yanked
* xmipy dropped python3.8 support, do the same
  * https://github.com/Deltares/xmipy/commit/6ab5966a5599ed38567fc9e2f7fdb3f1501c5d74#r139404396
  * https://github.com/Deltares/xmipy/pull/130