### PR TITLE
chore(format): apply isort rule, split long comment lines

### DIFF
--- a/autotest/conftest.py
+++ b/autotest/conftest.py
@@ -5,7 +5,6 @@ from tempfile import gettempdir
 
 import pytest
 from filelock import FileLock
-
 from modflow_devtools.download import download_and_unzip
 
 # import modflow-devtools fixtures

--- a/autotest/test_mf6_examples.py
+++ b/autotest/test_mf6_examples.py
@@ -1,9 +1,10 @@
 from pathlib import Path
 from shutil import copytree
-from modflowapi import run_simulation
 
 import pytest
+
 from autotest.conftest import is_nested
+from modflowapi import run_simulation
 
 pytestmark = pytest.mark.mf6
 dll = "libmf6"
@@ -35,13 +36,15 @@ def test_mf6_example_simulations(function_tmpdir, mf6_example_namfiles):
         pass
 
     def run_models():
-        # run models in order received (should be alphabetical, so gwf precedes gwt)
+        # run models in order received (should be alphabetical,
+        # so gwf precedes gwt)
         for namfile in mf6_example_namfiles:
             namfile_path = Path(namfile).resolve()
             model_path = namfile_path.parent
 
-            # working directory must be named according to the name file's parent (e.g.
-            # 'mf6gwf') because coupled models refer to each other with relative paths
+            # working directory must be named according to namefile's parent
+            # (e.g. 'mf6gwf') because coupled models refer to each other with
+            # relative paths
             wrkdir = (
                 Path(function_tmpdir / model_path.name)
                 if nested

--- a/examples/notebooks/Head_Monitor_Example.ipynb
+++ b/examples/notebooks/Head_Monitor_Example.ipynb
@@ -17,17 +17,19 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from pathlib import Path\n",
+    "\n",
+    "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
+    "from flopy.discretization import StructuredGrid\n",
+    "from flopy.plot import PlotMapView\n",
     "from IPython.display import (\n",
     "    clear_output,\n",
     "    display,\n",
-    ")  # remove this import if adapted to python script\n",
+    ")\n",
     "\n",
-    "from modflowapi import run_simulation, Callbacks\n",
-    "from flopy.discretization import StructuredGrid\n",
-    "from flopy.plot import PlotMapView\n",
-    "from pathlib import Path\n",
-    "import numpy as np\n",
-    "import matplotlib.pyplot as plt"
+    "# remove this import if adapted to python script\n",
+    "from modflowapi import Callbacks, run_simulation"
    ]
   },
   {
@@ -126,7 +128,8 @@
     "        idm = self.pmv.plot_inactive()\n",
     "        self.pc = self.pmv.plot_array(heads, vmin=self.vmin, vmax=self.vmax)\n",
     "\n",
-    "        # only applicable to jupyter notebooks, remove these two lines in python scipt\n",
+    "        # only applicable to jupyter notebooks, remove these\n",
+    "        # two lines in python scipt\n",
     "        display(self.fig)\n",
     "        if ml.kper == (ml.nper - 1) and ml.kstp == (ml.nstp - 1):\n",
     "            pass\n",

--- a/examples/notebooks/MODFLOW-API_extensions_objects.ipynb
+++ b/examples/notebooks/MODFLOW-API_extensions_objects.ipynb
@@ -19,10 +19,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import modflowapi\n",
-    "from modflowapi.extensions import ApiSimulation\n",
+    "import platform\n",
     "from pathlib import Path\n",
-    "import platform"
+    "\n",
+    "import modflowapi\n",
+    "from modflowapi.extensions import ApiSimulation"
    ]
   },
   {

--- a/examples/notebooks/Quickstart.ipynb
+++ b/examples/notebooks/Quickstart.ipynb
@@ -17,9 +17,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from pathlib import Path\n",
+    "\n",
     "import modflowapi\n",
-    "from modflowapi import Callbacks\n",
-    "from pathlib import Path"
+    "from modflowapi import Callbacks"
    ]
   },
   {

--- a/modflowapi/__init__.py
+++ b/modflowapi/__init__.py
@@ -1,6 +1,6 @@
 # ruff: noqa: F401, allow imports directly from modflowapi
-from .version import __version__
 from modflowapi.modflowapi import ModflowApi
 
 from . import extensions
 from .extensions.runner import Callbacks, run_simulation
+from .version import __version__

--- a/modflowapi/extensions/__init__.py
+++ b/modflowapi/extensions/__init__.py
@@ -1,4 +1,4 @@
 # ruff: noqa: F401, allow imports directly from modflowapi.extensions
-from .apisimulation import ApiSimulation
-from .apimodel import ApiModel
 from .apiexchange import ApiExchange
+from .apimodel import ApiModel
+from .apisimulation import ApiSimulation

--- a/modflowapi/extensions/apiexchange.py
+++ b/modflowapi/extensions/apiexchange.py
@@ -1,5 +1,5 @@
-from .pakbase import ListPackage
 from .apimodel import ApiMbase
+from .pakbase import ListPackage
 
 
 class ApiExchange(ApiMbase):

--- a/modflowapi/extensions/apimodel.py
+++ b/modflowapi/extensions/apimodel.py
@@ -1,11 +1,11 @@
+import numpy as np
+
 from .pakbase import (
     AdvancedPackage,
     ArrayPackage,
     ListPackage,
     package_factory,
 )
-import numpy as np
-
 
 gridshape = {
     "dis": ["nlay", "nrow", "ncol"],

--- a/modflowapi/extensions/apisimulation.py
+++ b/modflowapi/extensions/apisimulation.py
@@ -1,7 +1,8 @@
-from .apimodel import ApiMbase, ApiModel
-from .apiexchange import ApiExchange
-from .pakbase import ApiSlnPackage, ListPackage, ScalarPackage, package_factory
 import numpy as np
+
+from .apiexchange import ApiExchange
+from .apimodel import ApiMbase, ApiModel
+from .pakbase import ApiSlnPackage, ListPackage, ScalarPackage, package_factory
 
 
 class ApiSimulation:

--- a/modflowapi/extensions/data.py
+++ b/modflowapi/extensions/data.py
@@ -314,7 +314,8 @@ class ListInput(object):
 
 class ArrayPointer:
     """
-    Data object for storing single pointers and working with array based input data
+    Data object for storing single pointers and
+    working with array based input data
 
     Parameters
     ----------

--- a/modflowapi/extensions/runner.py
+++ b/modflowapi/extensions/runner.py
@@ -1,6 +1,7 @@
+from enum import Enum
+
 from .. import ModflowApi
 from .apisimulation import ApiSimulation
-from enum import Enum
 
 
 class Callbacks(Enum):

--- a/modflowapi/modflowapi.py
+++ b/modflowapi/modflowapi.py
@@ -1,4 +1,5 @@
 from xmipy import XmiWrapper
+
 from .util import amend_libmf6_path
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,6 +76,7 @@ extend-include = [
 ]
 
 [tool.ruff.lint]
+select = ["F", "E", "I001"]
 ignore = [
     "F841" # local variable assigned but never used
 ]

--- a/scripts/update_version.py
+++ b/scripts/update_version.py
@@ -3,9 +3,9 @@ import textwrap
 from datetime import datetime
 from os.path import basename
 from pathlib import Path
-from packaging.version import Version
 
 from filelock import FileLock
+from packaging.version import Version
 
 _project_name = "modflowapi"
 _project_root_path = Path(__file__).parent.parent
@@ -81,11 +81,11 @@ if __name__ == "__main__":
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog=textwrap.dedent(
             """\
-            Update version information stored in version.txt in the project root,
-            as well as several other files in the repository. If --version is not
-            provided, the version number will not be changed. A file lock is held
-            to synchronize file access. The version tag must comply with standard
-            '<major>.<minor>.<patch>' format conventions for semantic versioning.
+            Update version information in version.txt in the project root,
+            as well as several other files in the repository. If --version
+            is not provided, the version number will not be changed. A file
+            lock is held to synchronize file access. The version tag must be
+            standard '<major>.<minor>.<patch>' format for semantic versioning.
             """
         ),
     )
@@ -100,7 +100,7 @@ if __name__ == "__main__":
         "--get",
         required=False,
         action="store_true",
-        help="Just get the current version number, don't update anything (defaults to false)",
+        help="Get the current version number, no updates (defaults false)",
     )
     args = parser.parse_args()
 


### PR DESCRIPTION
* extend default rules in `pyproject.toml`
* apply import sorting
* split comment lines where needed to fully observe E501