### PR TITLE
ci(macos): install intel mac exes for pre-idm test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,6 +156,7 @@ jobs:
           path: ${{ github.workspace }}/autotest
           repo: executables
           tag: "14.0"
+          ostag: mac
 
       - name: Run autotests
         working-directory: ./autotest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,6 +151,15 @@ jobs:
           pip install .[test]
 
       - name: Install modflow executables
+        if: runner.os != 'macOS'
+        uses: modflowpy/install-modflow-action@v1
+        with:
+          path: ${{ github.workspace }}/autotest
+          repo: executables
+          tag: "14.0"
+
+      - name: Install modflow executables (macOS)
+        if: runner.os == 'macOS'
         uses: modflowpy/install-modflow-action@v1
         with:
           path: ${{ github.workspace }}/autotest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,7 +127,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-latest, windows-latest ]
+        os: [ ubuntu-latest, macos-13, windows-latest ]
         python-version: [ 3.9, "3.10", "3.11", "3.12" ]
     defaults:
       run:
@@ -151,21 +151,11 @@ jobs:
           pip install .[test]
 
       - name: Install modflow executables
-        if: runner.os != 'macOS'
         uses: modflowpy/install-modflow-action@v1
         with:
           path: ${{ github.workspace }}/autotest
           repo: executables
           tag: "14.0"
-
-      - name: Install modflow executables (macOS)
-        if: runner.os == 'macOS'
-        uses: modflowpy/install-modflow-action@v1
-        with:
-          path: ${{ github.workspace }}/autotest
-          repo: executables
-          tag: "14.0"
-          ostag: mac
 
       - name: Run autotests
         working-directory: ./autotest


### PR DESCRIPTION
For executables v14 [we did not yet have an ARM distribution](https://github.com/wpbonelli/modflowapi/actions/runs/10327748161/job/28593415089#step:5:432), use `macos-13` to get an Intel runner.

This is the first step towards fixing macOS CI. Several more to follow. This PR will not be fully green but I will merge anyway.