### PR TITLE
chore: enable colorful pytest output

### DIFF
--- a/autotest/pytest.ini
+++ b/autotest/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
-addopts = -ra
+addopts = -ra --color=yes
 python_files =
     test_*.py
 markers =


### PR DESCRIPTION
Use `--color=yes` in `pytest.ini` for colorful pytest CI logs