### PR TITLE
chore: reformat multi-line statements

### DIFF
--- a/autotest/conftest.py
+++ b/autotest/conftest.py
@@ -99,9 +99,8 @@ def pytest_generate_tests(metafunc):
                     for ix in idxs[::-1]:
                         models.append(model_namfiles.pop(ix))
 
-            models += list(
-                sorted(model_namfiles)
-            )  # sort remaining models in alphabetical order (gwe < gwt < prt)
+            # sort remaining models in alphabetical order (gwe < gwt < prt)
+            models += list(sorted(model_namfiles))
             simulations.append(models)
             print(
                 f"Simulation {model_name} has {len(models)} model(s):\n"

--- a/autotest/test_interface.py
+++ b/autotest/test_interface.py
@@ -7,11 +7,7 @@ import pytest
 from modflow_devtools.misc import set_dir
 
 from modflowapi import Callbacks, ModflowApi, run_simulation
-from modflowapi.extensions.pakbase import (
-    AdvancedPackage,
-    ArrayPackage,
-    ListPackage,
-)
+from modflowapi.extensions.pakbase import AdvancedPackage, ArrayPackage, ListPackage
 
 data_pth = Path("../examples/data")
 pytestmark = pytest.mark.extensions
@@ -386,9 +382,7 @@ def test_rhs_hcof_advanced(function_tmpdir):
             rhs3 = wel.rhs
 
             np.testing.assert_allclose(
-                rhs,
-                rhs3,
-                err_msg="set advanced var method not working properly",
+                rhs, rhs3, err_msg="set advanced var method not working properly"
             )
 
             npf = model.npf

--- a/autotest/test_mf6_examples.py
+++ b/autotest/test_mf6_examples.py
@@ -28,8 +28,7 @@ def test_mf6_example_simulations(function_tmpdir, mf6_example_namfiles):
     function_tmpdir = Path(function_tmpdir / "workspace")
 
     copytree(
-        src=namfile.parent.parent if nested else namfile.parent,
-        dst=function_tmpdir,
+        src=namfile.parent.parent if nested else namfile.parent, dst=function_tmpdir
     )
 
     def callback(sim, step):

--- a/examples/notebooks/Head_Monitor_Example.ipynb
+++ b/examples/notebooks/Head_Monitor_Example.ipynb
@@ -23,10 +23,7 @@
     "import numpy as np\n",
     "from flopy.discretization import StructuredGrid\n",
     "from flopy.plot import PlotMapView\n",
-    "from IPython.display import (\n",
-    "    clear_output,\n",
-    "    display,\n",
-    ")\n",
+    "from IPython.display import clear_output, display\n",
     "\n",
     "# remove this import if adapted to python script\n",
     "from modflowapi import Callbacks, run_simulation"

--- a/modflowapi/extensions/apimodel.py
+++ b/modflowapi/extensions/apimodel.py
@@ -1,19 +1,8 @@
 import numpy as np
 
-from .pakbase import (
-    AdvancedPackage,
-    ArrayPackage,
-    ListPackage,
-    package_factory,
-)
+from .pakbase import AdvancedPackage, ArrayPackage, ListPackage, package_factory
 
-gridshape = {
-    "dis": ["nlay", "nrow", "ncol"],
-    "disu": [
-        "nlay",
-        "ncpl",
-    ],
-}
+gridshape = {"dis": ["nlay", "nrow", "ncol"], "disu": ["nlay", "ncpl"]}
 
 
 class ApiMbase:

--- a/modflowapi/extensions/data.py
+++ b/modflowapi/extensions/data.py
@@ -34,15 +34,9 @@ class ListInput(object):
         self._nodevars = ("nodelist", "nexg", "maxats")
         self._boundvars = ("bound",)
 
-        self._maxbound = [
-            0,
-        ]
-        self._nbound = [
-            0,
-        ]
-        self._naux = [
-            0,
-        ]
+        self._maxbound = [0]
+        self._nbound = [0]
+        self._naux = [0]
         self._auxnames = []
         self._dtype = []
         self._reduced_to_var_addr = {}
@@ -432,12 +426,8 @@ class ArrayInput:
             self.var_addrs = var_addrs
             self.mf6 = mf6
 
-        self._maxbound = [
-            0,
-        ]
-        self._nbound = [
-            0,
-        ]
+        self._maxbound = [0]
+        self._nbound = [0]
         self._reduced_to_var_addr = {}
         self._set_arrays()
 

--- a/modflowapi/extensions/pakbase.py
+++ b/modflowapi/extensions/pakbase.py
@@ -18,13 +18,7 @@ pkgvars = {
         "nbound",
         "maxbound",
         "nodelist",
-        (
-            "bound",
-            (
-                "elev",
-                "cond",
-            ),
-        ),
+        ("bound", ("elev", "cond")),
         "naux",
         "auxname_cst",
         "auxvar",
@@ -33,14 +27,7 @@ pkgvars = {
         "nbound",
         "maxbound",
         "nodelist",
-        (
-            "bound",
-            (
-                "surface",
-                "rate",
-                "depth",
-            ),
-        ),
+        ("bound", ("surface", "rate", "depth")),
         # "pxdp:NSEG", "petm:NSEG"
         "naux",
         "auxname_cst",
@@ -50,13 +37,7 @@ pkgvars = {
         "nbound",
         "maxbound",
         "nodelist",
-        (
-            "bound",
-            (
-                "bhead",
-                "cond",
-            ),
-        ),
+        ("bound", ("bhead", "cond")),
         "naux",
         "auxname_cst",
         "auxvar",
@@ -149,15 +130,7 @@ pkgvars = {
     "gwt-gwt": ["nexg", "nodem1", "nodem2", "cl1", "cl2", "ihc", "hwva"],
     "gwe-gwe": ["nexg", "nodem1", "nodem2", "cl1", "cl2", "ihc", "hwva"],
     # simulation
-    "ats": [
-        "maxats",
-        "iperats",
-        "dt0",
-        "dtmin",
-        "dtmax",
-        "dtadj",
-        "dtfailadj",
-    ],
+    "ats": ["maxats", "iperats", "dt0", "dtmin", "dtmax", "dtadj", "dtfailadj"],
     "tdis": [
         "nper",
         "itmuni",
@@ -194,10 +167,7 @@ pkgvars = {
         "iscl",
         "iord",
     ],
-    "sln-ems": [
-        "icnvg",
-        "ttsoln",
-    ],
+    "sln-ems": ["icnvg", "ttsoln"],
 }
 
 
@@ -508,12 +478,7 @@ class ArrayPackage(PackageBase):
         Method that enables dynamic variable setting and distributes
         modflow variable storage and updates to the data object class
         """
-        if item in (
-            "model",
-            "pkg_name",
-            "pkg_type",
-            "var_addrs",
-        ):
+        if item in ("model", "pkg_name", "pkg_type", "var_addrs"):
             super().__setattr__(item, value)
 
         elif item.startswith("_"):
@@ -604,12 +569,7 @@ class ScalarPackage(PackageBase):
         Method that enables dynamic variable setting and distributes
         modflow variable storage and updates to the data object class
         """
-        if item in (
-            "model",
-            "pkg_name",
-            "pkg_type",
-            "var_addrs",
-        ):
+        if item in ("model", "pkg_name", "pkg_type", "var_addrs"):
             super().__setattr__(item, value)
 
         elif item.startswith("_"):
@@ -756,10 +716,6 @@ def package_factory(pkg_type, basepackage):
     cls_str = "".join(pkg_type.split("-"))
     cls_str = f"{cls_str[0].upper()}{cls_str[1:]}"
 
-    package = type(
-        f"Api{cls_str}Package",
-        (basepackage,),
-        {"__init__": __init__},
-    )
+    package = type(f"Api{cls_str}Package", (basepackage,), {"__init__": __init__})
 
     return package

--- a/scripts/update_version.py
+++ b/scripts/update_version.py
@@ -31,7 +31,7 @@ def update_version_py(timestamp: datetime, version: Version):
     with open(_version_py_path, "w") as f:
         f.write(
             f"# {_project_name} version file automatically "
-            + f"created using...{basename(__file__)}\n"
+            f"created using...{basename(__file__)}\n"
         )
         f.write(f"# created on...{timestamp.strftime('%B %d, %Y %H:%M:%S')}\n")
         f.write(f'__version__ = "{version}"\n')
@@ -48,10 +48,7 @@ def update_citation_cff(version: Version):
     log_update(_citation_cff_path, version)
 
 
-def update_version(
-    timestamp: datetime = datetime.now(),
-    version: Version = None,
-):
+def update_version(timestamp: datetime = datetime.now(), version: Version = None):
     lock_path = Path(_version_py_path.name + ".lock")
     try:
         lock = FileLock(lock_path)
@@ -88,10 +85,7 @@ if __name__ == "__main__":
         ),
     )
     parser.add_argument(
-        "-v",
-        "--version",
-        required=False,
-        help="Specify the release version",
+        "-v", "--version", required=False, help="Specify the release version"
     )
     parser.add_argument(
         "-g",


### PR DESCRIPTION
This PR refactors some multi-line statements. This was mostly automated by temporarily toggling this control in pyproject.toml:
```toml
[tool.ruff.format]
skip-magic-trailing-comma = true
```
then selecting some commits that condense multi-line statements to single, while rejecting other statements that are better represented over multiple lines.