### PR TITLE
ci: restore xdist on windows example tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,9 +176,4 @@ jobs:
       - name: Run autotests
         working-directory: ./autotest
         shell: bash -l {0}
-        run: |
-          if [[ $RUNNER_OS == 'Windows' ]]; then
-            uv run pytest -v test_mf6_examples.py
-          else
-            uv run pytest -v -n auto test_mf6_examples.py
-          fi
+        run: uv run pytest -v -n auto test_mf6_examples.py


### PR DESCRIPTION
Should be ok now after https://github.com/MODFLOW-ORG/modflow-devtools/pull/200