### PR TITLE
Fix number of stress period end states for multi-model simulations

### DIFF
--- a/autotest/test_mf6_examples.py
+++ b/autotest/test_mf6_examples.py
@@ -1,4 +1,5 @@
 import modflow_devtools.models as models
+import pandas as pd
 import pytest
 
 from modflowapi import run_simulation
@@ -12,6 +13,61 @@ skip = [
     "ex-prt-mp7-p04",
 ]
 
+temporary_skip_state_count = set(
+    [
+        # Skip state count tests for these model for now.
+        # There seems to be a different problem.
+        "ex-gwf-fhb",
+        "ex-gwf-nwt-p02a",
+        "ex-gwf-nwt-p02b",
+        "ex-gwe-geotherm",
+        "ex-gwe-radial-slow",
+    ]
+)
+
+
+class StateCollector:
+    """
+    Callback that collects the model state sequence.
+
+    THe attribute `states` is a list of tuples `(model_name, state_name)`,
+    where `state_name` is `callback_step.name`.
+    """
+
+    def __init__(self):
+        self.states = []
+
+    def __call__(self, sim, callback_step):
+        self.states.append((sim.model_names[0], callback_step.name))
+
+
+def count_states(states):
+    """
+    Count states per model.
+
+    The numbers of `start_state` and `end_state` should match.
+    """
+    states = pd.DataFrame(states, columns=["model", "state"])
+    counts = states.groupby(["model", "state"])[["state"]].agg("count")
+    counts.columns = ["counts"]
+    return counts
+
+
+def compare_counts(counts):
+    matches = [
+        ("iteration_start", "iteration_end"),
+        ("stress_period_start", "stress_period_end"),
+        ("timestep_start", "timestep_end"),
+    ]
+    for model_name in counts.index.levels[0]:
+        model = counts.loc[model_name]
+        for state1, state2 in matches:
+            count1, count2 = model.loc[state1].iloc[0], model.loc[state2].iloc[0]
+            assert count1 == count2, (
+                f"{state1}: {int(count1)}",
+                f"{state2}: {int(count2)}",
+            )
+
 
 @pytest.mark.parametrize("example_name", examples.keys())
 def test_example(function_tmpdir, example_name):
@@ -21,4 +77,8 @@ def test_example(function_tmpdir, example_name):
         model_relpath = model_name.rpartition(example_name + "/")[-1]
         model_workspace = function_tmpdir / model_relpath
         models.copy_to(model_workspace, model_name, verbose=True)
-        run_simulation(dll, model_workspace, lambda sim, step: None, verbose=True)
+        callback = StateCollector()
+        run_simulation(dll, model_workspace, callback=callback, verbose=True)
+        if model_name in temporary_skip_state_count:
+            counts = count_states(callback.states)
+            compare_counts(counts)

--- a/manualtest/collect_states.py
+++ b/manualtest/collect_states.py
@@ -1,0 +1,70 @@
+"""Test helper for sequence of model states."""
+
+from collections import defaultdict
+
+import pandas as pd
+
+import modflowapi
+
+
+class StateCollector:
+    """
+    Callback that collects the model state sequence.
+
+    THe attribute `states` is a list of tuples `(model_name, state_name)`,
+    where `state_name` is `callback_step.name`.
+    """
+
+    def __init__(self):
+        self.states = []
+
+    def __call__(self, sim, callback_step):
+        self.states.append((sim.model_names[0], callback_step.name))
+
+
+def run(dll, sim_path):
+    """Run a model and collect its sat sequence."""
+    callback = StateCollector()
+    modflowapi.run_simulation(dll=dll, sim_path=sim_path, callback=callback)
+    return callback.states
+
+
+def visualize_states(states, limit=None):
+    """
+    Visualize the state sequence by model.
+
+    This prints one tree-like sequence of state names per model.
+    Different state groups have different indentations to visualize the
+    flow.
+    """
+    indents = {
+        "initialize": 0,
+        "finalize": 0,
+        "stress_period_start": 4,
+        "stress_period_end": 4,
+        "timestep_start": 8,
+        "timestep_end": 8,
+        "iteration_start": 12,
+        "iteration_end": 12,
+    }
+    models = defaultdict(list)
+    for model_name, state in states:
+        models[model_name].append(state)
+    for model_name, model_states in models.items():
+        print(model_name)
+        for count, state in enumerate(model_states):
+            if limit and limit == count:
+                break
+            print(" " * indents[state], state)
+
+
+def count_states(states):
+    """
+    Count states per model.
+
+    The numbers of `start_state` and `end_state` should match.
+    """
+    states = pd.DataFrame(states, columns=["model", "state"])
+    counts = states.groupby(["model", "state"])[["state"]].agg("count")
+    counts.columns = ["counts"]
+    return counts

--- a/modflowapi/extensions/runner.py
+++ b/modflowapi/extensions/runner.py
@@ -119,7 +119,6 @@ def run_simulation(dll, sim_path, callback, verbose=False, _develop=False):
         if not has_converged:
             print(f"Simulation group: {sim_grp} DID NOT CONVERGE")
 
-
     try:
         callback(sim, Callbacks.finalize)
         mf6.finalize()

--- a/modflowapi/extensions/runner.py
+++ b/modflowapi/extensions/runner.py
@@ -110,6 +110,8 @@ def run_simulation(dll, sim_path, callback, verbose=False, _develop=False):
 
             callback(sim_grp, Callbacks.timestep_end)
             mf6.finalize_solve(sol_id)
+            if sim_grp.nstp == sim_grp.kstp + 1:
+                callback(sim_grp, Callbacks.stress_period_end)
 
         mf6.finalize_time_step()
         current_time = mf6.get_current_time()
@@ -117,8 +119,7 @@ def run_simulation(dll, sim_path, callback, verbose=False, _develop=False):
         if not has_converged:
             print(f"Simulation group: {sim_grp} DID NOT CONVERGE")
 
-        if sim_grp.nstp == sim_grp.kstp + 1:
-            callback(sim_grp, Callbacks.stress_period_end)
+
 
     try:
         callback(sim, Callbacks.finalize)

--- a/modflowapi/extensions/runner.py
+++ b/modflowapi/extensions/runner.py
@@ -120,7 +120,6 @@ def run_simulation(dll, sim_path, callback, verbose=False, _develop=False):
             print(f"Simulation group: {sim_grp} DID NOT CONVERGE")
 
 
-
     try:
         callback(sim, Callbacks.finalize)
         mf6.finalize()


### PR DESCRIPTION
## Problem

The number of start and end states such as `Callback.timestep_start` and `Callback.timestep_end` or  `Callback.stress_period_start` and  `Callback.stress_period_end` handed to the callback function should match in number over the simulation run time.
Furthermore, the states should be grouped in a parenthesis-like fashion with these levels:

```
initialize
    stress_period_start
        timestep_start
            iteration_start
            iteration_end
        timestep_end
    stress_period_end
finalize
``` 
This holds for the model `ex-gwf-advtidal` from the [MODFLOW 6 examples](https://github.com/MODFLOW-ORG/modflow6-examples):


<table border="1" class="dataframe">
  <thead>
    <tr style="text-align: right;">
      <th></th>
      <th></th>
      <th>counts</th>
    </tr>
    <tr>
      <th>model</th>
      <th>state</th>
      <th></th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <th rowspan="8" valign="top">ex-gwf-advtidal</th>
      <th>finalize</th>
      <td>1</td>
    </tr>
    <tr>
      <th>initialize</th>
      <td>1</td>
    </tr>
    <tr>
      <th>iteration_end</th>
      <td>1099</td>
    </tr>
    <tr>
      <th>iteration_start</th>
      <td>1099</td>
    </tr>
    <tr>
      <th>stress_period_end</th>
      <td>4</td>
    </tr>
    <tr>
      <th>stress_period_start</th>
      <td>4</td>
    </tr>
    <tr>
      <th>timestep_end</th>
      <td>361</td>
    </tr>
    <tr>
      <th>timestep_start</th>
      <td>361</td>
    </tr>
  </tbody>
</table>

But it this does not apply to the model `ex-gwe-vsc`, which has several sub-models. The count of the state `stress_period_end` doesn't match the number  of `stress_period_start` state expect for one sub-model:

<table border="1" class="dataframe">
  <thead>
    <tr style="text-align: right;">
      <th></th>
      <th></th>
      <th>counts</th>
    </tr>
    <tr>
      <th>model</th>
      <th>state</th>
      <th></th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <th rowspan="6" valign="top">ex-gwe-vsc-02</th>
      <th>iteration_end</th>
      <td>2483</td>
    </tr>
    <tr>
      <th>iteration_start</th>
      <td>2483</td>
    </tr>
    <tr>
      <th>stress_period_end</th>
      <td>2</td>
    </tr>
    <tr>
      <th>stress_period_start</th>
      <td>2</td>
    </tr>
    <tr>
      <th>timestep_end</th>
      <td>732</td>
    </tr>
    <tr>
      <th>timestep_start</th>
      <td>732</td>
    </tr>
    <tr>
      <th rowspan="5" valign="top">ex-gwf-vsc-01</th>
      <th>iteration_end</th>
      <td>733</td>
    </tr>
    <tr>
      <th>iteration_start</th>
      <td>733</td>
    </tr>
    <tr>
      <th>stress_period_start</th>
      <td>2</td>
    </tr>
    <tr>
      <th>timestep_end</th>
      <td>732</td>
    </tr>
    <tr>
      <th>timestep_start</th>
      <td>732</td>
    </tr>
    <tr>
      <th rowspan="5" valign="top">ex-gwf-vsc-02</th>
      <th>iteration_end</th>
      <td>1464</td>
    </tr>
    <tr>
      <th>iteration_start</th>
      <td>1464</td>
    </tr>
    <tr>
      <th>stress_period_start</th>
      <td>2</td>
    </tr>
    <tr>
      <th>timestep_end</th>
      <td>732</td>
    </tr>
    <tr>
      <th>timestep_start</th>
      <td>732</td>
    </tr>
    <tr>
      <th rowspan="5" valign="top">ex-gwt-vsc-01</th>
      <th>iteration_end</th>
      <td>2699</td>
    </tr>
    <tr>
      <th>iteration_start</th>
      <td>2699</td>
    </tr>
    <tr>
      <th>stress_period_start</th>
      <td>2</td>
    </tr>
    <tr>
      <th>timestep_end</th>
      <td>732</td>
    </tr>
    <tr>
      <th>timestep_start</th>
      <td>732</td>
    </tr>
    <tr>
      <th rowspan="7" valign="top">ex-gwt-vsc-02</th>
      <th>finalize</th>
      <td>1</td>
    </tr>
    <tr>
      <th>initialize</th>
      <td>1</td>
    </tr>
    <tr>
      <th>iteration_end</th>
      <td>2703</td>
    </tr>
    <tr>
      <th>iteration_start</th>
      <td>2703</td>
    </tr>
    <tr>
      <th>stress_period_start</th>
      <td>2</td>
    </tr>
    <tr>
      <th>timestep_end</th>
      <td>732</td>
    </tr>
    <tr>
      <th>timestep_start</th>
      <td>732</td>
    </tr>
  </tbody>
</table>

## Solution

The problem is the location of the code 

```python
if sim_grp.nstp == sim_grp.kstp + 1:
    callback(sim_grp, Callbacks.stress_period_end)
```

in `modflowapi.extension.runner.py` after the solution loop. Moving this code inside this loop fixes the matching problem of the stress period states:

<table border="1" class="dataframe">
  <thead>
    <tr style="text-align: right;">
      <th></th>
      <th></th>
      <th>counts</th>
    </tr>
    <tr>
      <th>model</th>
      <th>state</th>
      <th></th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <th rowspan="6" valign="top">ex-gwe-vsc-02</th>
      <th>iteration_end</th>
      <td>2483</td>
    </tr>
    <tr>
      <th>iteration_start</th>
      <td>2483</td>
    </tr>
    <tr>
      <th>stress_period_end</th>
      <td>2</td>
    </tr>
    <tr>
      <th>stress_period_start</th>
      <td>2</td>
    </tr>
    <tr>
      <th>timestep_end</th>
      <td>732</td>
    </tr>
    <tr>
      <th>timestep_start</th>
      <td>732</td>
    </tr>
    <tr>
      <th rowspan="6" valign="top">ex-gwf-vsc-01</th>
      <th>iteration_end</th>
      <td>733</td>
    </tr>
    <tr>
      <th>iteration_start</th>
      <td>733</td>
    </tr>
    <tr>
      <th>stress_period_end</th>
      <td>2</td>
    </tr>
    <tr>
      <th>stress_period_start</th>
      <td>2</td>
    </tr>
    <tr>
      <th>timestep_end</th>
      <td>732</td>
    </tr>
    <tr>
      <th>timestep_start</th>
      <td>732</td>
    </tr>
    <tr>
      <th rowspan="6" valign="top">ex-gwf-vsc-02</th>
      <th>iteration_end</th>
      <td>1464</td>
    </tr>
    <tr>
      <th>iteration_start</th>
      <td>1464</td>
    </tr>
    <tr>
      <th>stress_period_end</th>
      <td>2</td>
    </tr>
    <tr>
      <th>stress_period_start</th>
      <td>2</td>
    </tr>
    <tr>
      <th>timestep_end</th>
      <td>732</td>
    </tr>
    <tr>
      <th>timestep_start</th>
      <td>732</td>
    </tr>
    <tr>
      <th rowspan="6" valign="top">ex-gwt-vsc-01</th>
      <th>iteration_end</th>
      <td>2699</td>
    </tr>
    <tr>
      <th>iteration_start</th>
      <td>2699</td>
    </tr>
    <tr>
      <th>stress_period_end</th>
      <td>2</td>
    </tr>
    <tr>
      <th>stress_period_start</th>
      <td>2</td>
    </tr>
    <tr>
      <th>timestep_end</th>
      <td>732</td>
    </tr>
    <tr>
      <th>timestep_start</th>
      <td>732</td>
    </tr>
    <tr>
      <th rowspan="8" valign="top">ex-gwt-vsc-02</th>
      <th>finalize</th>
      <td>1</td>
    </tr>
    <tr>
      <th>initialize</th>
      <td>1</td>
    </tr>
    <tr>
      <th>iteration_end</th>
      <td>2703</td>
    </tr>
    <tr>
      <th>iteration_start</th>
      <td>2703</td>
    </tr>
    <tr>
      <th>stress_period_end</th>
      <td>2</td>
    </tr>
    <tr>
      <th>stress_period_start</th>
      <td>2</td>
    </tr>
    <tr>
      <th>timestep_end</th>
      <td>732</td>
    </tr>
    <tr>
      <th>timestep_start</th>
      <td>732</td>
    </tr>
  </tbody>
</table>

## Tools

The script  `manualtest.collect_states.py` provides functions to run the model with a callback function that records the states and creates the above shown DataFrames:

```python
from collect_states import count_states, run

state_sequence = run(dll, sim_path)
df = count_states(state_sequence)
```

The function `visualize_states` allows to show the nesting of the states.

```python
from collect_states import visualize_states, run

state_sequence = run(dll, sim_path)
visualize_states(state_sequence)
```

Example output:

```
ex-gwf-advtidal
 initialize
     stress_period_start
         timestep_start
             iteration_start
             iteration_end
             iteration_start
             iteration_end
             iteration_start
             iteration_end
             iteration_start
...
```

```
ex-gwt-vsc-02
 initialize
     stress_period_start
         timestep_start
             iteration_start
             iteration_end
             iteration_start
             iteration_end
             iteration_start
             iteration_end
             iteration_start
ex-gwf-vsc-01
     stress_period_start
         timestep_start
             iteration_start
             iteration_end
             iteration_start
             iteration_end
         timestep_end
         timestep_start
             iteration_start
             iteration_end
ex-gwf-vsc-02
     stress_period_start
         timestep_start
             iteration_start
             iteration_end
             iteration_start
             iteration_end
         timestep_end
         timestep_start
             iteration_start
             iteration_end
ex-gwt-vsc-01
     stress_period_start
         timestep_start
             iteration_start
             iteration_end
             iteration_start
             iteration_end
             iteration_start
             iteration_end
             iteration_start
             iteration_end
ex-gwe-vsc-02
     stress_period_start
         timestep_start
             iteration_start
             iteration_end
             iteration_start
             iteration_end
             iteration_start
             iteration_end
         timestep_end
         timestep_start

....
```