### PR TITLE
docs: install exes in conf.py

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -4,8 +4,14 @@
 # https://www.sphinx-doc.org/en/master/usage/configuration.html
 
 import os
+from pathlib import Path
+from flopy.utils.get_modflow import run_main as get_modflow
 import sys
 sys.path.insert(0, os.path.abspath('../'))
+from modflowapi import __version__
+
+# -- Determine if this is a development or release version ------------------
+branch_or_version = __version__ if "dev" not in __version__ else "develop"
 
 # -- Project information -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
@@ -34,3 +40,8 @@ html_static_path = ['_static']
 nbsphinx_custom_formats = {
     '.py': ['jupytext.reads', {'fmt': 'py:light'}],
 }
+
+# -- Install MODFLOW --------------------------------------------------------
+bindir = Path.cwd() / "examples" / "notebooks"
+repo = "modflow6-nightly-build" if branch_or_version == "develop" else "modflow6"
+get_modflow(str(bindir), repo=repo)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,13 +59,14 @@ lint = [
     "ruff",
 ]
 docs = [
+    "modflowapi[test]",
     "sphinx",
     "sphinx-rtd-theme",
     "myst-parser",
     "jupyter",
     "jupytext",
     "nbsphinx",
-    "ipython"
+    "ipython",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,7 @@ docs = [
     "jupytext",
     "nbsphinx",
     "ipython",
+    "flopy",
 ]
 
 [project.urls]


### PR DESCRIPTION
Followup to #74, the examples need `libmf6`