### PR TITLE
include extensions example on RTD site, add note about workaround

### DIFF
--- a/docs/examples/notebooks/Extensions.py
+++ b/docs/examples/notebooks/Extensions.py
@@ -275,6 +275,10 @@ wel.get_advanced_var("ibcnum")
 # Let's close the existing modflowapi shared library object and look at an example of how this is all
 # used in practice.
 
+# Note: the full prepare/solve/finalize sequence below is temporarily required to work around a bug
+# in MODFLOW 6. The bug has been patched, but the patch has not been released yet. The sequence can
+# be reduced to just `mf6.finalize()` when the patch is released.
+
 mf6.prepare_solve(model.solution_id)
 mf6.solve(model.solution_id)
 mf6.finalize_solve(model.solution_id)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -14,6 +14,7 @@ An extension to `xmipy` for the MODFLOW API.
    :caption: User Guide
 
    examples/notebooks/Quickstart
+   examples/notebooks/Extensions
    examples/notebooks/Head_Monitor_Example
 
 .. autosummary::


### PR DESCRIPTION
the extensions example was omitted until now because of #78, include it. and mention in the example that the workaround is temporary until https://github.com/MODFLOW-ORG/modflow6/pull/2322 is released 