### PR TITLE
chore(dependencies): switch to release of modflow-devtools

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ dependencies = [
 dev = ["modflowapi[test,lint]"]
 test = [
     "filelock",
-    "modflow-devtools[dfn] @ git+https://github.com/MODFLOW-ORG/modflow-devtools.git",
+    "modflow-devtools>=1.7.0",
     "pytest!=8.1.0",
     "pytest-order",
     "pytest-xdist",
@@ -82,10 +82,6 @@ packages = ["modflowapi"]
 
 [tool.hatch.version]
 path = "modflowapi/version.py"
-
-[tool.hatch.metadata]
-# temporary, until new devtools release
-allow-direct-references = true
 
 [tool.ruff]
 line-length = 120


### PR DESCRIPTION
#65 switched to a custom development branch of devtools. Switch back to the released version (and stick with it going forward). This means we can remove `allow-direct-references` from hatch config in `pyproject.toml`.