### PR TITLE
support logger_level init parameter

### DIFF
--- a/modflowapi/modflowapi.py
+++ b/modflowapi/modflowapi.py
@@ -20,10 +20,12 @@ class ModflowApi(XmiWrapper):
         lib_dependency: str = None,
         working_directory: str = ".",
         timing: bool = False,
+        logger_level: int | str = 0,
     ):
         super().__init__(
             amend_libmf6_path(lib_path),
             lib_dependency=lib_dependency,
             working_directory=working_directory,
             timing=timing,
+            logger_level=logger_level,
         )


### PR DESCRIPTION
add `logger_level` init parameter to `ModflowApi` and pass it through to xmipy base init method