### PR TITLE
fix(apisimulation.py): fix exchange-related bugs

### DIFF
--- a/autotest/test_interface.py
+++ b/autotest/test_interface.py
@@ -7,6 +7,7 @@ import pytest
 from modflow_devtools.misc import set_dir
 
 from modflowapi import Callbacks, ModflowApi, run_simulation
+from modflowapi.extensions.apiexchange import ApiExchange
 from modflowapi.extensions.pakbase import AdvancedPackage, ArrayPackage, ListPackage
 
 data_pth = Path("../docs/examples/data")
@@ -292,6 +293,20 @@ def test_two_models(function_tmpdir):
         if step == Callbacks.initialize:
             if len(sim.models) != 2:
                 raise AssertionError("Invalid number of models")
+
+            assert sim.exchange_names == ["gwf-gwf_1"]
+
+            exchange = sim.get_exchange()
+            assert isinstance(exchange, ApiExchange)
+
+            named_exchange = sim.get_exchange("gwf-gwf_1")
+            assert named_exchange is exchange
+
+            with pytest.raises(KeyError):
+                sim.get_exchange("not_a_real_exchange")
+
+            assert "Exchanges include" in repr(sim)
+            assert "gwf-gwf_1" in repr(sim)
 
     name = "two_models"
     sim_pth = data_pth / name

--- a/modflowapi/extensions/apisimulation.py
+++ b/modflowapi/extensions/apisimulation.py
@@ -61,7 +61,7 @@ class ApiSimulation:
         if self._exchanges:
             s += "\tExchanges include:\n"
             for name, exchange in self._exchanges.items():
-                f"\t\t{name}: {type(exchange)}\n"
+                s += f"\t\t{name}: {type(exchange)}\n"
 
         return s
 
@@ -256,8 +256,7 @@ class ApiSimulation:
             raise AssertionError("No exchanges are present in this simulation")
 
         if exchange_name is None:
-            for _, exg in self._exchanges:
-                return exg
+            return next(iter(self._exchanges.values()))
 
         else:
             if exchange_name in self._exchanges:
@@ -375,7 +374,7 @@ class ApiSimulation:
 
         # sim_packages: tdis, gwf-gwf, sln
         exchanges = {}
-        for exchange_name in exchanges:
+        for exchange_name in exchange_names:
             exchange = ApiExchange(mf6, exchange_name)
             exchanges[exchange_name.lower()] = exchange
 


### PR DESCRIPTION
- `__repr__` silently dropped the exchanges section (missing `s +=`)
- `get_exchange(None)` failed to return the first detected exchange
- `ApiSimulation.load` iterated the just-created empty `exchanges` dict instead of `exchange_names`, so `exchanges` and `get_exchange()` never returned a real exchange