### PR TITLE
fix(runner.py): cap Picard iterations with ATS

### DIFF
--- a/modflowapi/extensions/runner.py
+++ b/modflowapi/extensions/runner.py
@@ -88,7 +88,7 @@ def run_simulation(dll, sim_path, callback, verbose=False, _develop=False):
 
             if sim_grp.ats_period[0]:
                 mindt = sim_grp.ats_period[-1]
-                while sim_grp.delt > mindt:
+                while sim_grp.delt > mindt and kiter < maxiter:
                     sim_grp.iteration = kiter
                     callback(sim_grp, Callbacks.iteration_start)
                     has_converged = mf6.solve(sol_id)


### PR DESCRIPTION
The ATS conditional branch in `run_simulation()` did not cap Picard iterations. A timestep failing to converge would call `mf6.solve()` indefinitely instead of giving up after `maxiter` tries. This caused crashes (access violations) on Windows in the `ex-gwt-adv-schemes` example model. I think the "central" scheme is borderline-unstable on this model, it converges on the Linux and macOS builds but can fail on Windows.

Note however that ATS is not truly supported right now by the API: there is no way currently to hook into the retry mechanism. This is a temporary stopgap to prevent crashes until ATS is supported. See 

- https://github.com/MODFLOW-ORG/modflow6/issues/2756
- https://github.com/MODFLOW-ORG/modflow6/pull/2794
- #24

Close #98